### PR TITLE
add 'div {' prefix and '}' suffix to css`` for most common pattern

### DIFF
--- a/src/main/kotlin/com/intellij/StyledComponents/StyledComponentsInjector.kt
+++ b/src/main/kotlin/com/intellij/StyledComponents/StyledComponentsInjector.kt
@@ -22,7 +22,7 @@ class StyledComponentsInjector : MultiHostInjector {
                         PlatformPatterns.psiElement(JSExpression::class.java)
                                 .withFirstChild(styledPattern))), "div {", "}"),
                 PlaceInfo(taggedTemplate(withReferenceName("extend")), "div {", "}"),
-                PlaceInfo(taggedTemplate("css")),
+                PlaceInfo(taggedTemplate("css"), "div {", "}"),
                 PlaceInfo(taggedTemplate("injectGlobal")),
                 PlaceInfo(taggedTemplate("keyframes"), "@keyframes foo {", "}")
         )

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>com.deadlock.scsyntax</id>
     <name>Styled Components</name>
-    <version>1.0.1</version>
+    <version>1.0.3</version>
     <vendor email="hossam.saraya@gmail.com" url="http://www.saraya.io">Kodehouse</vendor>
 
     <!-- Enable plugin for all products -->

--- a/src/test/InjectionTest.kt
+++ b/src/test/InjectionTest.kt
@@ -8,6 +8,16 @@ import com.intellij.util.containers.ContainerUtil
 import org.junit.Assert
 
 class InjectionTest : LightCodeInsightFixtureTestCase() {
+    fun testCss() {
+        doTest("let css = css`\n" +
+                "  color:red;\n" +
+                "  width:100px;\n" +
+                "  height:100px;`", "div {\n" +
+                "  color:red;\n" +
+                "  width:100px;\n" +
+                "  height:100px;}")
+    }
+
     fun testSimpleComponent() {
         doTest("const Title = styled.h1`\n" +
                 "  font-size: 1.5em;\n" +


### PR DESCRIPTION
Fixes #19

![image](https://user-images.githubusercontent.com/7509842/30056760-a8708a68-923c-11e7-9e31-b9dba4f8f36c.png)
