### PR TITLE
Improved argument injections handling

### DIFF
--- a/src/main/kotlin/com/intellij/StyledComponents/InjectionUtils.kt
+++ b/src/main/kotlin/com/intellij/StyledComponents/InjectionUtils.kt
@@ -1,40 +1,100 @@
 package com.intellij.styledComponents
 
-import com.intellij.lang.javascript.JSTokenTypes
+import com.intellij.lang.javascript.psi.JSExpression
+import com.intellij.lang.javascript.psi.JSLiteralExpression
+import com.intellij.lang.javascript.psi.JSReferenceExpression
 import com.intellij.lang.javascript.psi.ecma6.JSStringTemplateExpression
-import com.intellij.openapi.util.Key
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiLanguageInjectionHost
+import com.intellij.psi.PsiRecursiveElementWalkingVisitor
 import com.intellij.util.ArrayUtil
 import com.intellij.util.containers.ContainerUtil
 import java.util.*
+import kotlin.math.max
 
 private const val EXTERNAL_FRAGMENT = "EXTERNAL_FRAGMENT"
 
-fun getInjectionPlaces(myQuotedLiteral: PsiElement): List<StringPlace> {
-    if (myQuotedLiteral is JSStringTemplateExpression) {
-        val templateExpression = myQuotedLiteral
-        val ranges = templateExpression.stringRanges
+fun getInjectionPlaces(quotedLiteral: PsiElement): List<StringPlace> {
+    if (quotedLiteral is JSStringTemplateExpression) {
+        val ranges = quotedLiteral.stringRanges
+        val arguments = quotedLiteral.arguments
+
         if (ranges.isNotEmpty()) {
             val result = ArrayList<StringPlace>(ranges.size)
-            val quotedLiteralNode = myQuotedLiteral.getNode()
-            val backquote = quotedLiteralNode.findChildByType(JSTokenTypes.BACKQUOTE)
-            val backquoteOffset = if (backquote != null) backquote.startOffset - quotedLiteralNode.startOffset else -1
+            var lastArgumentIndex = -1
+
             for (i in ranges.indices) {
                 val range = ranges[i]
-                val prefix = if (i == 0 && range.startOffset > backquoteOffset + 1) EXTERNAL_FRAGMENT else null
-                val suffix = if (i < ranges.size - 1 || range.endOffset < myQuotedLiteral.getTextLength() - 1) EXTERNAL_FRAGMENT else null
+
+                // styled.div`padding: ${'none'}${'IGNORED_ARGUMENT'}${'display'}: none;`
+                //           |_________|_______|____________________|___________|______|
+                //              Text    Suffix         Ignored          Prefix    Text
+                //          |__________________|                    |__________________|
+                //                1 fragment                               2 fragment
+
+                var currentIndex = adjustPrecedingArgumentIndex(lastArgumentIndex, range, arguments)
+                val prefix = if (currentIndex != lastArgumentIndex)
+                    getArgumentPlaceholder(arguments.elementAtOrNull(currentIndex), currentIndex) else null
+
+                val suffix = getArgumentPlaceholder(arguments.elementAtOrNull(++currentIndex), currentIndex)
+
+                lastArgumentIndex = currentIndex
                 result.add(StringPlace(prefix, range, suffix))
             }
             return result
         }
-        if (!ArrayUtil.isEmpty(templateExpression.arguments)) {
+        if (!ArrayUtil.isEmpty(arguments)) {
             return ContainerUtil.emptyList()
         }
     }
-    val endOffset = Math.max(myQuotedLiteral.textLength - 1, 1)
+
+    val endOffset = max(quotedLiteral.textLength - 1, 1)
     return listOf(StringPlace(null, TextRange.create(1, endOffset), null))
 }
 
 
-data class StringPlace(val prefix: String?, val range: TextRange, val suffix: String?) 
+private fun adjustPrecedingArgumentIndex(startIndex: Int, range: TextRange, arguments: Array<JSExpression>): Int {
+    var current = startIndex
+
+    while (true) {
+        val argument = arguments.getOrNull(current + 1)
+        if (argument == null || argument.textRangeInParent.startOffset > range.endOffset) return current
+        current++
+    }
+}
+
+private fun getArgumentPlaceholder(argument: JSExpression?, index: Int): String? {
+    if (argument == null) return null
+
+    var hasChildInjection = false
+    argument.accept(object : PsiRecursiveElementWalkingVisitor() {
+        override fun visitElement(element: PsiElement) {
+            if (element is PsiLanguageInjectionHost && StyledComponentsInjector.matchInjectionTarget(element) != null) {
+                hasChildInjection = true
+                stopWalking()
+            }
+
+            super.visitElement(element)
+        }
+    })
+    if (hasChildInjection) return null
+
+    if (argument is JSLiteralExpression) {
+        val value = argument.value
+        if (value != null) {
+            return value.toString()
+        }
+    }
+
+    if (argument is JSReferenceExpression && argument.qualifier == null) {
+        val referenceName = argument.referenceName
+        if (referenceName != null) {
+            return referenceName
+        }
+    }
+
+    return "${EXTERNAL_FRAGMENT}_$index"
+}
+
+data class StringPlace(val prefix: String?, val range: TextRange, val suffix: String?)

--- a/src/main/kotlin/com/intellij/StyledComponents/StyledComponentsConfigurable.kt
+++ b/src/main/kotlin/com/intellij/StyledComponents/StyledComponentsConfigurable.kt
@@ -5,7 +5,7 @@ import com.intellij.lang.javascript.JavascriptLanguage
 import com.intellij.lang.javascript.refactoring.JSNamesValidation
 import com.intellij.openapi.editor.event.DocumentEvent
 import com.intellij.openapi.editor.event.DocumentListener
-import com.intellij.openapi.fileTypes.PlainTextLanguage
+import com.intellij.openapi.fileTypes.PlainTextFileType
 import com.intellij.openapi.options.SearchableConfigurable
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.ComponentValidator
@@ -30,7 +30,7 @@ class StyledComponentsConfigurable(private val project: Project) : SearchableCon
     private val tagsModel = TagsModel()
     private val disposable = Disposer.newDisposable()
     private val myTagPrefixesField = object : JBListTable(JBTable(tagsModel), disposable) {
-        override fun getRowRenderer(p0: Int): JBTableRowRenderer = object : EditorTextFieldJBTableRowRenderer(project, PlainTextLanguage.INSTANCE, disposable) {
+        override fun getRowRenderer(p0: Int): JBTableRowRenderer = object : EditorTextFieldJBTableRowRenderer(project, PlainTextFileType.INSTANCE, disposable) {
             override fun getText(p0: JTable?, index: Int): String = tagsModel.myTags[index]
         }
 
@@ -49,6 +49,7 @@ class StyledComponentsConfigurable(private val project: Project) : SearchableCon
                 add(editor, BorderLayout.NORTH)
                 validator.updateInfo(getErrorText(editor.text)?.let { ValidationInfo(it, editor) })
             }
+
             override fun getFocusableComponents(): Array<JComponent> = arrayOf(preferredFocusedComponent)
             override fun getPreferredFocusedComponent(): JComponent = getComponent(0) as JComponent
 
@@ -72,6 +73,7 @@ class StyledComponentsConfigurable(private val project: Project) : SearchableCon
             }
         }
     }
+
     override fun isModified(): Boolean {
         return !getPrefixesFromUi().contentEquals((myConfiguration.getTagPrefixes()))
     }


### PR DESCRIPTION
@anstarovoyt

#76

The general idea is to ignore nested styled-components injections which we could assume valid CSS fragments instead of replacing them with `EXTERNAL_FRAGMENT`.

So this code
```
const OptionLabel = styled.div`
  padding: 5px;
  ${props => css`
    margin-bottom: 0.3em;
  `};
`;
```

will be replaced with syntactically correct

```
const OptionLabel = styled.div`
  padding: 5px;
`;
```

This kind of injections will be handled as before:
```
let atStart = styled.div`${getPropName()}: red`
let atEnd = styled.div`color: ${getColor()}`
```

```
let atStart = styled.div`EXTERNAL_FRAGMENT: red`
let atEnd = styled.div`color: EXTERNAL_FRAGMENT`
```

I think this is a safe heuristic that we can use now, and it should cover all the most painful cases.

Also, I provided a temporary registry key to disable this new behavior if something goes wrong for someone: `styled.components.experimental.injections`.