### PR TITLE
discord-link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # webstorm-styled-components
+
+![Discord](https://img.shields.io/discord/818449605409767454?logo=discord)
+
 Support for styled-components 💅 in WebStorm
 
 The plugin can be installed in WebStorm, IntelliJ IDEA Ultimate, PhpStorm, PyCharm Pro, and RubyMine v2017.2 and above.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # webstorm-styled-components
 
-![Discord](https://img.shields.io/discord/818449605409767454?logo=discord)
+<a href="https://discord.gg/hfGUrbrxaU">![Discord](https://img.shields.io/discord/818449605409767454?logo=discord)</a>
 
 Support for styled-components 💅 in WebStorm
 


### PR DESCRIPTION
Spectrum is shutting down and Styled Components organisation has been migrating over to Discord. Could you add the link on the readme? There is a #webstorm channel already available if people need help there. 

https://github.com/styled-components/vscode-styled-components and https://styled-components.com/ already have it set